### PR TITLE
Add timeout to fetchPage and fetchViaJina

### DIFF
--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -82,6 +82,7 @@ async function fetchPage(url: string): Promise<{ html: string; ok: boolean; stat
       "Accept-Language": "en-US,en;q=0.5",
     },
     redirect: "follow",
+    signal: AbortSignal.timeout(15_000),
   });
 
   return { html: await res.text(), ok: res.ok, status: res.status };
@@ -94,6 +95,7 @@ async function fetchViaJina(url: string): Promise<string | null> {
         Accept: "text/html",
         "X-Return-Format": "html",
       },
+      signal: AbortSignal.timeout(15_000),
     });
     if (!res.ok) return null;
     return res.text();


### PR DESCRIPTION
## Summary
- Add `AbortSignal.timeout(15_000)` to `fetchPage()` and `fetchViaJina()` in the scraper
- These were the only two fetch calls missing timeouts — all other fetches (manifest, image probing, logo color extraction) already had 5s timeouts
- Without this, sites with bot protection (e.g. linear.com) can cause the request to hang indefinitely

## Test plan
- [ ] Extract brand assets from `linear.com` — should complete or error within ~15s instead of hanging forever
- [ ] Extract from a normal site (e.g. `stripe.com`) — should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)