### PR TITLE
Add share button next to brand name on results

### DIFF
--- a/components/brand-results.tsx
+++ b/components/brand-results.tsx
@@ -12,16 +12,7 @@ export function BrandResults({ data }: { data: BrandExtractionResult }) {
   const [copied, setCopied] = useState(false);
 
   const handleShare = async () => {
-    const url = window.location.href;
-    if (navigator.share) {
-      try {
-        await navigator.share({ title: `${data.brandName ?? "Brand"} - OpenBrand`, url });
-        return;
-      } catch {
-        // User cancelled or share failed, fall through to clipboard
-      }
-    }
-    await navigator.clipboard.writeText(url);
+    await navigator.clipboard.writeText(window.location.href);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
@@ -39,19 +30,24 @@ export function BrandResults({ data }: { data: BrandExtractionResult }) {
           )}
           <button
             onClick={handleShare}
-            className="p-1.5 rounded-lg text-neutral-400 hover:text-neutral-600 hover:bg-neutral-100 transition-colors"
+            className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-neutral-400 hover:text-neutral-600 hover:bg-neutral-100 transition-colors text-sm"
             title="Share result"
           >
             {copied ? (
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <polyline points="20 6 9 17 4 12" />
-              </svg>
+              <>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+                <span>Copied!</span>
+              </>
             ) : (
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
-                <polyline points="16 6 12 2 8 6" />
-                <line x1="12" y1="2" x2="12" y2="15" />
-              </svg>
+              <>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                  <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+                </svg>
+                <span>Share</span>
+              </>
             )}
           </button>
         </div>

--- a/components/brand-results.tsx
+++ b/components/brand-results.tsx
@@ -9,17 +9,52 @@ import { JsonView } from "./json-view";
 
 export function BrandResults({ data }: { data: BrandExtractionResult }) {
   const [view, setView] = useState<"visual" | "json">("visual");
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = async () => {
+    const url = window.location.href;
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: `${data.brandName ?? "Brand"} - OpenBrand`, url });
+        return;
+      } catch {
+        // User cancelled or share failed, fall through to clipboard
+      }
+    }
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
 
   return (
     <div className="space-y-8">
       <div className="flex items-center justify-between">
-        {data.brandName ? (
-          <h2 className="text-2xl font-semibold text-neutral-900">
-            {data.brandName}
-          </h2>
-        ) : (
-          <div />
-        )}
+        <div className="flex items-center gap-3">
+          {data.brandName ? (
+            <h2 className="text-2xl font-semibold text-neutral-900">
+              {data.brandName}
+            </h2>
+          ) : (
+            <div />
+          )}
+          <button
+            onClick={handleShare}
+            className="p-1.5 rounded-lg text-neutral-400 hover:text-neutral-600 hover:bg-neutral-100 transition-colors"
+            title="Share result"
+          >
+            {copied ? (
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+            ) : (
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+                <polyline points="16 6 12 2 8 6" />
+                <line x1="12" y1="2" x2="12" y2="15" />
+              </svg>
+            )}
+          </button>
+        </div>
         <div className="flex rounded-lg border border-neutral-200 overflow-hidden text-sm">
           <button
             onClick={() => setView("visual")}


### PR DESCRIPTION
## Summary
- Adds a share button (upload/arrow icon) to the right of the brand name in the results view
- Uses the Web Share API on supported devices (mobile/tablets), falls back to copying the URL to clipboard
- Shows a checkmark animation for 2 seconds after copying to confirm the action

## Test plan
- [ ] Extract a brand and verify the share icon appears next to the brand name
- [ ] Click the share button on desktop — URL should be copied to clipboard, checkmark shown
- [ ] Click the share button on mobile — native share sheet should appear
- [ ] Verify the shared URL contains the `?url=` param and loads the result when opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)